### PR TITLE
refactor!: Consolidate systemd unit name to "k0s"

### DIFF
--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -116,7 +116,7 @@ in
       isWorker = cfg.role == "worker";
       isLeader = (cfg.role == "single") || (cfg.controller.isLeader or false);
       requireJoinToken = isWorker || (!isLeader && !isExternalEtcd);
-      unitName = "k0s" + subcommand;
+      unitName = "k0s";
       configFile = (pkgs.formats.yaml { }).generate "k0s.yaml" {
         apiVersion = "k0s.k0sproject.io/v1beta1";
         kind = "Cluster";

--- a/tests/cluster.nix
+++ b/tests/cluster.nix
@@ -44,7 +44,7 @@ in
     in
     ''
       start_all()
-      ctrl.wait_for_unit("k0scontroller")
+      ctrl.wait_for_unit("k0s")
       ctrl.wait_for_file("/run/k0s/status.sock")
       ctrl.succeed("${k0s}/bin/k0s status")
 
@@ -55,12 +55,12 @@ in
         return stdout.strip()
 
       for node in [wrkr1, wrkr2]:
-        info=node.get_unit_info("k0sworker")
+        info=node.get_unit_info("k0s")
         assert info['ActiveState'] == "inactive"
         token = mkJoinToken()
         node.succeed(f"bash -c 'echo  {token} > ${tokenFile}'")
-        node.systemctl("start k0sworker")
-        node.wait_for_unit("k0sworker")
+        node.systemctl("start k0s")
+        node.wait_for_unit("k0s")
         node.wait_for_file("/run/k0s/status.sock")
         node.succeed("${k0s}/bin/k0s status")
     '';

--- a/tests/ctrl-wrkr.nix
+++ b/tests/ctrl-wrkr.nix
@@ -25,7 +25,7 @@
     in
     ''
       start_all()
-      node1.wait_for_unit("k0scontroller")
+      node1.wait_for_unit("k0s")
       node1.wait_for_file("/run/k0s/status.sock")
       node1.succeed("${k0s}/bin/k0s status")
     '';

--- a/tests/graceful-shutdown.nix
+++ b/tests/graceful-shutdown.nix
@@ -33,7 +33,7 @@
     in
     ''
       start_all()
-      node1.wait_for_unit("k0scontroller")
+      node1.wait_for_unit("k0s")
       node1.wait_for_file("/run/k0s/status.sock")
       node1.succeed("${k0s}/bin/k0s status")
 

--- a/tests/single.nix
+++ b/tests/single.nix
@@ -22,7 +22,7 @@
     in
     ''
       start_all()
-      node1.wait_for_unit("k0scontroller")
+      node1.wait_for_unit("k0s")
       node1.wait_for_file("/run/k0s/status.sock")
       node1.succeed("${k0s}/bin/k0s status")
     '';


### PR DESCRIPTION
The systemd service is now always named "k0s" instead of "k0scontroller" or "k0sworker" depending on the role.

This should make customization simpler, because the service unit is always just called "k0s". Also scripting around this should be simpler, because one does not have to work out the unit name based on the role of a node.

This change is breaking though, because it does need adjustments of customizations and scripts which depend on the unit name.