### PR TITLE
Add description to the option types

### DIFF
--- a/checks/types.nix
+++ b/checks/types.nix
@@ -1,0 +1,27 @@
+{ lib, pkgs }:
+let
+  types = import ../nixos/types.nix { inherit lib; };
+
+  isUndescribed = type: type.description == lib.types.str.description;
+  undescribedTypes = lib.filterAttrs (_: isUndescribed) types;
+
+  report = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (name: type: "${name}: ${type.description}") types
+  );
+in
+pkgs.runCommand "k0s-option-type-descriptions"
+  {
+    preferLocalBuild = true;
+    passAsFile = [ "report" ];
+    inherit report;
+    undescribed = lib.concatStringsSep " " (lib.attrNames undescribedTypes);
+  }
+  ''
+    cat "$reportPath"
+    echo
+    if [ -n "$undescribed" ]; then
+      echo "These types in nixos/types.nix describe themselves as their base type: $undescribed" >&2
+      exit 1
+    fi
+    touch $out
+  ''

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,9 @@
             };
           }
         )
+        // {
+          option-types = import ./checks/types.nix { inherit lib pkgs; };
+        }
       );
 
     };

--- a/nixos/types.nix
+++ b/nixos/types.nix
@@ -173,18 +173,34 @@ let
         && (isValidIpV6Brackets host || isValidIpV4 host || isValidDnsName host);
 in
 rec {
-  ipV4 = addCheck str isValidIpV4;
-  ipV6 = addCheck str isValidIpV6;
+  ipV4 = addCheck str isValidIpV4 // {
+    description = "IPv4 address";
+  };
+  ipV6 = addCheck str isValidIpV6 // {
+    description = "IPv6 address";
+  };
   ip = either ipV4 ipV6;
-  dnsName = addCheck str isValidDnsName;
+  dnsName = addCheck str isValidDnsName // {
+    description = "DNS name";
+  };
   ipOrDnsName = either ip dnsName;
-  cidrV4 = addCheck str isValidCidrV4;
-  cidrV6 = addCheck str isValidCidrV6;
+  cidrV4 = addCheck str isValidCidrV4 // {
+    description = "IPv4 CIDR";
+  };
+  cidrV6 = addCheck str isValidCidrV6 // {
+    description = "IPv6 CIDR";
+  };
   cidr = either cidrV4 cidrV6;
-  ipV4WithPort = addCheck str isValidIpV4WithPort;
-  ipV6WithPort = addCheck str isValidIpV6WithPort;
+  ipV4WithPort = addCheck str isValidIpV4WithPort // {
+    description = "IPv4 address with port";
+  };
+  ipV6WithPort = addCheck str isValidIpV6WithPort // {
+    description = "IPv6 address with port";
+  };
   ipWithPort = either ipV4WithPort ipV6WithPort;
-  etcdEndpoint = addCheck str isValidEtcdEndpoint;
+  etcdEndpoint = addCheck str isValidEtcdEndpoint // {
+    description = "etcd endpoint URL";
+  };
   emptyOrPath = either (enum [ "" ]) path;
   image = submodule {
     options = {


### PR DESCRIPTION
Got here while working on issue #27 , the description in the option types makes the error reporting easier to understand. Also added the check to verify that we should have a description different from the default string for our custom types.