### PR TITLE
Fix option type defects

### DIFF
--- a/checks/docs.nix
+++ b/checks/docs.nix
@@ -1,0 +1,21 @@
+{
+  pkgs,
+  nixpkgs,
+  module,
+}:
+let
+  eval = import (nixpkgs + "/nixos/lib/eval-config.nix") {
+    inherit pkgs;
+    # Dropping this falls back to builtins.currentSystem, which is
+    # unavailable in a pure evaluation.
+    system = null;
+    modules = [ module ];
+  };
+
+  doc = pkgs.nixosOptionsDoc {
+    options = eval.options.services.k0s;
+    # TODO: Drop this once every option carries a description
+    warningsAreErrors = false;
+  };
+in
+doc.optionsCommonMark

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,10 @@
         )
         // {
           option-types = import ./checks/types.nix { inherit lib pkgs; };
+          option-docs = import ./checks/docs.nix {
+            inherit nixpkgs pkgs;
+            module = self.nixosModules.default;
+          };
         }
       );
 

--- a/nixos/featureGate.nix
+++ b/nixos/featureGate.nix
@@ -18,13 +18,15 @@ in
       type = bool;
     };
     components = mkOption {
-      type = nullOr listOf enum [
-        "kube-apiserver"
-        "kube-controller-manager"
-        "kubelet"
-        "kube-scheduler"
-        "kube-proxy"
-      ];
+      type = nullOr (
+        listOf (enum [
+          "kube-apiserver"
+          "kube-controller-manager"
+          "kubelet"
+          "kube-scheduler"
+          "kube-proxy"
+        ])
+      );
       default = null;
     };
   };

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -32,7 +32,7 @@ in
   ];
 
   options.services.k0s = {
-    enable = mkEnableOption (lib.mdDoc "Enable the k0s Kubernetes distribution.");
+    enable = mkEnableOption "the k0s Kubernetes distribution";
 
     package = mkPackageOption pkgs "k0s" { };
 


### PR DESCRIPTION
Found two small issues when I was exploring how to render the documentation. Interestingly they only surfaced when I rendered the docs, that's also why the test is about rendering the documentation.

Regarding the `featureGates` I think it was quite unusable so far due to the issue. 

The other one around the mdDocs seems to be a removed library function. 

There is a TODO comment inside, because we still have a bunch of options without descriptions. Hope we'll be able to catch up on this over time. 