### PR TITLE
Build and publish option documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix build -L '.#option-docs'
+      # result symlinks into the read-only store; the artifact step needs a
+      # plain writable tree.
+      - run: cp -rL --no-preserve=mode,ownership result _site
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/checks/docs.nix
+++ b/checks/docs.nix
@@ -4,6 +4,27 @@
   module,
 }:
 let
+  inherit (pkgs) lib;
+
+  sourceRoot = "${toString ../.}/";
+  repository = "https://github.com/nix-community/k0s-nix/blob/main";
+
+  linkToRepository =
+    declaration:
+    let
+      path = toString declaration;
+    in
+    if lib.hasPrefix sourceRoot path then
+      let
+        relative = lib.removePrefix sourceRoot path;
+      in
+      {
+        name = relative;
+        url = "${repository}/${relative}";
+      }
+    else
+      declaration;
+
   eval = import (nixpkgs + "/nixos/lib/eval-config.nix") {
     inherit pkgs;
     # Dropping this falls back to builtins.currentSystem, which is
@@ -14,6 +35,12 @@ let
 
   doc = pkgs.nixosOptionsDoc {
     options = eval.options.services.k0s;
+    transformOptions =
+      option:
+      option
+      // {
+        declarations = map linkToRepository option.declarations;
+      };
     # TODO: Drop this once every option carries a description
     warningsAreErrors = false;
   };

--- a/docs/options.nix
+++ b/docs/options.nix
@@ -7,7 +7,8 @@ let
   inherit (pkgs) lib;
 
   sourceRoot = "${toString ../.}/";
-  repository = "https://github.com/nix-community/k0s-nix/blob/main";
+  revision = "main";
+  repository = "https://github.com/nix-community/k0s-nix/blob/${revision}";
 
   linkToRepository =
     declaration:
@@ -44,5 +45,25 @@ let
     # TODO: Drop this once every option carries a description
     warningsAreErrors = false;
   };
+
+  manual = pkgs.writeText "manual.md" ''
+    # k0s-nix module options {#book-k0s-nix-options}
+    ## Reference for the `services.k0s` NixOS module
+
+    ```{=include=} options
+    id-prefix: opt-
+    list-id: configuration-variable-list
+    source: ${doc.optionsJSON}/share/doc/nixos/options.json
+    ```
+  '';
 in
-doc.optionsCommonMark
+pkgs.runCommand "k0s-nix-option-docs" { nativeBuildInputs = [ pkgs.nixos-render-docs ]; } ''
+  mkdir $out
+  cp ${pkgs.path}/doc/style.css $out/style.css
+  nixos-render-docs manual html \
+    --manpage-urls ${pkgs.path}/doc/manpage-urls.json \
+    --revision ${revision} \
+    --stylesheet style.css \
+    ${manual} \
+    $out/index.html
+''

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
 
       overlays.default = final: prev: genPackages prev;
 
-      nixosModules.default = import ./nixos/k0s.nix;
+      nixosModules.default = ./nixos/k0s.nix;
 
       formatter = (lib.genAttrs allSystems) (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,15 +28,17 @@
         "x86_64-darwin"
       ];
       allSystems = k0sSystems ++ darwinSystems;
-      forAllK0sSystems = lib.genAttrs k0sSystems;
+      forAllSystems = lib.genAttrs allSystems;
     in
     {
-      packages = forAllK0sSystems (
+      packages = forAllSystems (
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
-        genPackages pkgs
+        # k0s itself is a linux binary; the option documentation builds
+        # anywhere.
+        lib.optionalAttrs (lib.elem system k0sSystems) (genPackages pkgs)
         // {
           option-docs = import ./docs/options.nix {
             inherit nixpkgs pkgs;
@@ -49,12 +51,13 @@
 
       nixosModules.default = ./nixos/k0s.nix;
 
-      formatter = (lib.genAttrs allSystems) (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
 
-      checks = (lib.genAttrs k0sSystems) (
+      checks = forAllSystems (
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          # Empty on darwin, where there is no k0s package to test.
           versions = builtins.filter (lib.hasPrefix "k0s_") (builtins.attrNames self.packages.${system});
           tests = map (name: lib.strings.removeSuffix ".nix" name) (
             builtins.attrNames (builtins.readDir ./tests)

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,12 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         genPackages pkgs
+        // {
+          option-docs = import ./docs/options.nix {
+            inherit nixpkgs pkgs;
+            module = self.nixosModules.default;
+          };
+        }
       );
 
       overlays.default = final: prev: genPackages prev;
@@ -49,7 +55,7 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          versions = builtins.filter (name: name != "k0s") (builtins.attrNames self.packages.${system});
+          versions = builtins.filter (lib.hasPrefix "k0s_") (builtins.attrNames self.packages.${system});
           tests = map (name: lib.strings.removeSuffix ".nix" name) (
             builtins.attrNames (builtins.readDir ./tests)
           );
@@ -88,10 +94,7 @@
         )
         // {
           option-types = import ./checks/types.nix { inherit lib pkgs; };
-          option-docs = import ./checks/docs.nix {
-            inherit nixpkgs pkgs;
-            module = self.nixosModules.default;
-          };
+          option-docs = self.packages.${system}.option-docs;
         }
       );
 


### PR DESCRIPTION
Renders the option set as a single HTML page and publishes it for easy inspection.

Can be built the following way:

```
nix build .#option-docs
```

## Needs a follow up after merge

Pages have to be enabled with the source configured to github actions.