### PR TITLE
Opt-in validation via k0s

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,15 @@ Error: spec: network: calico.mode: Forbidden: dual-stack for calico is only supp
 
 Set `services.k0s.enableConfigCheck = true` to add it to `system.checks`, so
 that `nixos-rebuild` fails on an invalid configuration instead of the node
-reporting it later. It is off by default: it runs `services.k0s.package` on
-the builder, so the rules applied are those of the k0s version this host
-runs, and a version bump can fail a build that passed before. It is skipped
-where the builder cannot execute that binary, as when cross building.
+reporting it later. k0s runs the same validation when the controller starts
+and refuses to start on an error, so this only moves the failure earlier.
+
+It is off by default because k0s validates against the host as well as the
+file, and a build has no host to offer. Control plane load balancing is one
+such case; `hostDependentCases` in `checks/config.nix` demonstrates it.
+
+The check is also skipped where the builder cannot execute
+`services.k0s.package`, as when cross building.
 
 
 ### Token handling to join the cluster

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ they cannot see:
 Error: spec: network: calico.mode: Forbidden: dual-stack for calico is only supported for mode `bird`
 ```
 
-Set `services.k0s.enableConfigCheck = true` to make the system build depend
-on it. It is off by default: it runs the packaged `k0s` binary on the
+Set `services.k0s.enableConfigCheck = true` to add it to `system.checks`, so
+that `nixos-rebuild` fails on an invalid configuration and the node never
+sees it. It is off by default: it runs the packaged `k0s` binary on the
 builder, and ties every build to one k0s version's rules.
 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ nix build .#nixosConfigurations.test.config.system.build.toplevel
 Inspect the result in `./result`.
 
 
+### Validate the generated configuration
+
+The module renders `/etc/k0s/k0s.yaml` from `services.k0s.spec`. Build
+`validatedConfigFile` in your own flake to have `k0s config validate` run
+over the result:
+
+```sh
+nix build .#nixosConfigurations.<host>.config.services.k0s.validatedConfigFile
+```
+
+The option types reject a malformed value, and k0s reports the combinations
+they cannot see:
+
+```
+Error: spec: network: calico.mode: Forbidden: dual-stack for calico is only supported for mode `bird`
+```
+
+Set `services.k0s.validateConfig = true` to make the system build depend on
+it. It is off by default: it runs the packaged `k0s` binary on the builder,
+and ties every build to one k0s version's rules.
+
+
 ### Token handling to join the cluster
 
 `k0s` uses a token to join the cluster. The token has to be placed into

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Error: spec: network: calico.mode: Forbidden: dual-stack for calico is only supp
 ```
 
 Set `services.k0s.enableConfigCheck = true` to add it to `system.checks`, so
-that `nixos-rebuild` fails on an invalid configuration and the node never
-sees it. It is off by default: it runs the packaged `k0s` binary on the
-builder, and ties every build to one k0s version's rules.
+that `nixos-rebuild` fails on an invalid configuration instead of the node
+reporting it later. It is off by default: it runs `services.k0s.package` on
+the builder, so the rules applied are those of the k0s version this host
+runs, and a version bump can fail a build that passed before. It is skipped
+where the builder cannot execute that binary, as when cross building.
 
 
 ### Token handling to join the cluster

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ they cannot see:
 Error: spec: network: calico.mode: Forbidden: dual-stack for calico is only supported for mode `bird`
 ```
 
-Set `services.k0s.validateConfig = true` to make the system build depend on
-it. It is off by default: it runs the packaged `k0s` binary on the builder,
-and ties every build to one k0s version's rules.
+Set `services.k0s.enableConfigCheck = true` to make the system build depend
+on it. It is off by default: it runs the packaged `k0s` binary on the
+builder, and ties every build to one k0s version's rules.
 
 
 ### Token handling to join the cluster

--- a/checks/config.nix
+++ b/checks/config.nix
@@ -9,10 +9,10 @@ let
   base = {
     services.k0s = {
       enable = true;
+      inherit package;
       role = lib.mkDefault "single";
       spec.api.address = "10.0.0.1";
     };
-    services.k0s.package = package;
   };
 
   cases = {

--- a/checks/config.nix
+++ b/checks/config.nix
@@ -92,10 +92,6 @@ let
     ) config.system.checks;
 
   deployedConfig = config: config.environment.etc."k0s/k0s.yaml".source;
-
-  # Naming a store path in the build would make this check depend on the
-  # derivation it is asserting about, and on all of system.checks with it.
-  report = value: builtins.unsafeDiscardStringContext (toString value);
 in
 pkgs.runCommand "k0s-config-cases"
   {
@@ -104,8 +100,8 @@ pkgs.runCommand "k0s-config-cases"
     wiredWhenEnabled = lib.boolToString (isWired withCheck);
     wiredWhenDefault = lib.boolToString (isWired withoutCheck);
     enabledChecks = lib.concatMapStringsSep " " (check: check.name) withCheck.system.checks;
-    deployedWithCheck = report (deployedConfig withCheck);
-    deployedWithoutCheck = report (deployedConfig withoutCheck);
+    deployedWithCheck = deployedConfig withCheck;
+    deployedWithoutCheck = deployedConfig withoutCheck;
   }
   ''
     echo "==> system.checks with enableConfigCheck: $enabledChecks"

--- a/checks/config.nix
+++ b/checks/config.nix
@@ -77,10 +77,39 @@ let
 
   k0sOf = extra: (evalCase extra).services.k0s;
 
+  # Invalid in the build sandbox, but valid on the target node.
+  hostDependentCases = {
+    control-plane-load-balancing-without-interface = {
+      extra = {
+        services.k0s.spec.network.controlPlaneLoadBalancing = {
+          enabled = true;
+          keepalived.vrrpInstances = [
+            {
+              virtualIPs = [ "10.0.0.2/24" ];
+              authPass = "changeme";
+            }
+          ];
+        };
+      };
+      message = "failed to get default NIC";
+    };
+  };
+
   validate = name: extra: ''
     echo "==> ${name}"
     ${package}/bin/k0s config validate --config ${(k0sOf extra).configFile}
   '';
+
+  expectFailure =
+    name:
+    { extra, message }:
+    let
+      failed = pkgs.testers.testBuildFailure (k0sOf extra).validatedConfigFile;
+    in
+    ''
+      echo "==> ${name}, which cannot be validated in a build"
+      grep -F ${lib.escapeShellArg message} ${failed}/testBuildFailure.log
+    '';
 
   withCheck = evalCase { services.k0s.enableConfigCheck = true; };
   withoutCheck = evalCase { };
@@ -121,6 +150,8 @@ pkgs.runCommand "k0s-config-cases"
       fail "enableConfigCheck changes the deployed /etc/k0s/k0s.yaml"
 
     ${lib.concatStringsSep "\n" (lib.mapAttrsToList validate cases)}
+
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList expectFailure hostDependentCases)}
 
     echo "==> validatedConfigFile"
     test -s ${(k0sOf { }).validatedConfigFile}

--- a/checks/config.nix
+++ b/checks/config.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  pkgs,
+  nixpkgs,
+  module,
+  package,
+}:
+let
+  base = {
+    services.k0s = {
+      enable = true;
+      role = lib.mkDefault "single";
+      spec.api.address = "10.0.0.1";
+    };
+    services.k0s.package = package;
+  };
+
+  cases = {
+    kuberouter-etcd = { };
+
+    calico-vxlan = {
+      services.k0s.spec.network.provider = "calico";
+    };
+
+    calico-bird-dual-stack = {
+      services.k0s.spec.network = {
+        provider = "calico";
+        calico.mode = "bird";
+        dualStack = {
+          enabled = true;
+          IPv6podCIDR = "fd00::/108";
+          IPv6serviceCIDR = "fd01::/108";
+        };
+      };
+    };
+
+    kine = {
+      services.k0s.spec.storage.type = "kine";
+    };
+
+    node-local-load-balancing = {
+      services.k0s.spec.network.nodeLocalLoadBalancing.enabled = true;
+    };
+
+    control-plane-load-balancing = {
+      services.k0s.spec.network.controlPlaneLoadBalancing = {
+        enabled = true;
+        keepalived.vrrpInstances = [
+          {
+            virtualIPs = [ "10.0.0.2/24" ];
+            authPass = "changeme";
+            # Unset, k0s looks up the default route's NIC; a sandbox has none.
+            interface = "eth0";
+          }
+        ];
+      };
+    };
+
+    controller = {
+      services.k0s.role = "controller";
+    };
+  };
+
+  evalCase =
+    extra:
+    (import (nixpkgs + "/nixos/lib/eval-config.nix") {
+      inherit pkgs;
+      # Dropping this falls back to builtins.currentSystem, which is
+      # unavailable in a pure evaluation.
+      system = null;
+      modules = [
+        module
+        base
+        extra
+      ];
+    }).config.services.k0s;
+
+  validate = name: extra: ''
+    echo "==> ${name}"
+    ${package}/bin/k0s config validate --config ${(evalCase extra).configFile}
+  '';
+in
+pkgs.runCommand "k0s-config-cases"
+  {
+    preferLocalBuild = true;
+  }
+  ''
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList validate cases)}
+
+    echo "==> validatedConfigFile"
+    test -s ${(evalCase { }).validatedConfigFile}
+
+    touch $out
+  ''

--- a/checks/config.nix
+++ b/checks/config.nix
@@ -112,18 +112,17 @@ pkgs.runCommand "k0s-config-cases"
     echo "==> deployed with the check:    $deployedWithCheck"
     echo "==> deployed without the check: $deployedWithoutCheck"
 
-    if [ "$wiredWhenEnabled" != "true" ]; then
-      echo "enableConfigCheck does not add validatedConfigFile to system.checks" >&2
+    fail() {
+      echo "$1" >&2
       exit 1
-    fi
-    if [ "$wiredWhenDefault" != "false" ]; then
-      echo "validatedConfigFile is in system.checks without enableConfigCheck" >&2
-      exit 1
-    fi
-    if [ "$deployedWithCheck" != "$deployedWithoutCheck" ]; then
-      echo "enableConfigCheck changes the deployed /etc/k0s/k0s.yaml" >&2
-      exit 1
-    fi
+    }
+
+    [ "$wiredWhenEnabled" = "true" ] ||
+      fail "enableConfigCheck does not add validatedConfigFile to system.checks"
+    [ "$wiredWhenDefault" = "false" ] ||
+      fail "validatedConfigFile is in system.checks without enableConfigCheck"
+    [ "$deployedWithCheck" = "$deployedWithoutCheck" ] ||
+      fail "enableConfigCheck changes the deployed /etc/k0s/k0s.yaml"
 
     ${lib.concatStringsSep "\n" (lib.mapAttrsToList validate cases)}
 

--- a/checks/config.nix
+++ b/checks/config.nix
@@ -73,22 +73,62 @@ let
         base
         extra
       ];
-    }).config.services.k0s;
+    }).config;
+
+  k0sOf = extra: (evalCase extra).services.k0s;
 
   validate = name: extra: ''
     echo "==> ${name}"
-    ${package}/bin/k0s config validate --config ${(evalCase extra).configFile}
+    ${package}/bin/k0s config validate --config ${(k0sOf extra).configFile}
   '';
+
+  withCheck = evalCase { services.k0s.enableConfigCheck = true; };
+  withoutCheck = evalCase { };
+
+  isWired =
+    config:
+    lib.any (
+      check: check.drvPath == config.services.k0s.validatedConfigFile.drvPath
+    ) config.system.checks;
+
+  deployedConfig = config: config.environment.etc."k0s/k0s.yaml".source;
+
+  # Naming a store path in the build would make this check depend on the
+  # derivation it is asserting about, and on all of system.checks with it.
+  report = value: builtins.unsafeDiscardStringContext (toString value);
 in
 pkgs.runCommand "k0s-config-cases"
   {
     preferLocalBuild = true;
+
+    wiredWhenEnabled = lib.boolToString (isWired withCheck);
+    wiredWhenDefault = lib.boolToString (isWired withoutCheck);
+    enabledChecks = lib.concatMapStringsSep " " (check: check.name) withCheck.system.checks;
+    deployedWithCheck = report (deployedConfig withCheck);
+    deployedWithoutCheck = report (deployedConfig withoutCheck);
   }
   ''
+    echo "==> system.checks with enableConfigCheck: $enabledChecks"
+    echo "==> deployed with the check:    $deployedWithCheck"
+    echo "==> deployed without the check: $deployedWithoutCheck"
+
+    if [ "$wiredWhenEnabled" != "true" ]; then
+      echo "enableConfigCheck does not add validatedConfigFile to system.checks" >&2
+      exit 1
+    fi
+    if [ "$wiredWhenDefault" != "false" ]; then
+      echo "validatedConfigFile is in system.checks without enableConfigCheck" >&2
+      exit 1
+    fi
+    if [ "$deployedWithCheck" != "$deployedWithoutCheck" ]; then
+      echo "enableConfigCheck changes the deployed /etc/k0s/k0s.yaml" >&2
+      exit 1
+    fi
+
     ${lib.concatStringsSep "\n" (lib.mapAttrsToList validate cases)}
 
     echo "==> validatedConfigFile"
-    test -s ${(evalCase { }).validatedConfigFile}
+    test -s ${(k0sOf { }).validatedConfigFile}
 
     touch $out
   ''

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,16 @@
             };
           }
         )
+        // builtins.listToAttrs (
+          map (version: {
+            name = "${version}_config-validate";
+            value = import ./checks/config.nix {
+              inherit lib pkgs nixpkgs;
+              module = self.nixosModules.default;
+              package = self.packages.${system}.${version};
+            };
+          }) versions
+        )
         // {
           option-types = import ./checks/types.nix { inherit lib pkgs; };
           option-docs = self.packages.${system}.option-docs;

--- a/nixos/cplb.nix
+++ b/nixos/cplb.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  config,
   ...
 }@args:
 let
-  inherit (lib) mkEnableOption mkOption optionalAttrs;
+  inherit (lib) mkEnableOption mkOption;
   inherit (lib.types)
     str
     enum
@@ -28,7 +27,7 @@ in
       default = "Keepalived";
     };
 
-    keepalived = optionalAttrs (config.enabled && config.type == "Keepalived") (mkOption {
+    keepalived = mkOption {
       description = ''
         Contains configuration options related to the "Keepalived" type of load balancing.
       '';
@@ -162,6 +161,6 @@ in
         };
       };
       default = { };
-    });
+    };
   };
 }

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -12,6 +12,7 @@ let
     mkOption
     mkIf
     literalMD
+    optional
     optionalString
     concatMapAttrs
     ;
@@ -45,9 +46,6 @@ let
       '';
 
   canValidate = pkgs.stdenv.buildPlatform.canExecute pkgs.stdenv.hostPlatform;
-
-  deployedConfig =
-    if cfg.enableConfigCheck && canValidate then cfg.validatedConfigFile else cfg.configFile;
 in
 {
   imports = [
@@ -166,9 +164,10 @@ in
 
     enableConfigCheck = mkOption {
       description = ''
-        Whether the system build depends on
-        {option}`services.k0s.validatedConfigFile`, so that an invalid
-        configuration fails the build instead of the node.
+        Adds {option}`services.k0s.validatedConfigFile` to
+        {option}`system.checks`, so that an invalid configuration fails
+        the system build instead of the node. What the node deploys is
+        the same either way.
 
         Off by default: it runs the packaged k0s binary on the builder,
         and ties every build to the rules of one k0s version. It is
@@ -204,7 +203,9 @@ in
         }
       ];
 
-      environment.etc."k0s/k0s.yaml".source = deployedConfig;
+      environment.etc."k0s/k0s.yaml".source = cfg.configFile;
+
+      system.checks = optional (cfg.enableConfigCheck && canValidate) cfg.validatedConfigFile;
 
       systemd.services.${unitName} = {
         description = "k0s - Zero Friction Kubernetes";
@@ -230,7 +231,7 @@ in
           Restart = "always";
           ExecStart =
             "${cfg.package}/bin/k0s ${subcommand} --data-dir=${cfg.dataDir}"
-            + optionalString (cfg.role != "worker") " --config=${deployedConfig}"
+            + optionalString (cfg.role != "worker") " --config=${cfg.configFile}"
             + optionalString (cfg.role == "single") " --single"
             + optionalString (cfg.role == "controller+worker") " --enable-worker --no-taints"
             + optionalString requireJoinToken " --token-file=${cfg.tokenFile}"

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -155,7 +155,9 @@ in
         depend on it.
 
         It runs the packaged k0s binary, so it needs a builder that can
-        execute it.
+        execute it, and it runs under Nix's sandbox. Configuration that
+        k0s checks against the host it runs on cannot be validated
+        there.
       '';
       type = package;
       readOnly = true;

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -86,6 +86,7 @@ in
             description = ''
               The leader is used to generate the join tokens.
             '';
+            type = bool;
             default = false;
           };
         };

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -169,11 +169,12 @@ in
         the system build instead of the node. What the node deploys is
         the same either way.
 
-        Off by default: it runs {option}`services.k0s.package` on the
-        builder, so the rules applied are those of the k0s version this
-        host runs, and a version bump can fail a build that passed
-        before. It is skipped silently where the builder cannot execute
-        that binary.
+        Off by default: k0s validates against the host as well as the
+        file, so a configuration that is valid on a node can fail in a
+        build. Control plane load balancing is one such case.
+
+        The check is skipped silently where the builder cannot execute
+        {option}`services.k0s.package`.
       '';
       type = bool;
       default = false;

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -11,16 +11,43 @@ let
     mkRemovedOptionModule
     mkOption
     mkIf
+    literalMD
     optionalString
     concatMapAttrs
     ;
   inherit (lib.types)
+    bool
     str
     enum
+    package
     path
     submodule
     ;
   cfg = config.services.k0s;
+
+  generatedConfig = (pkgs.formats.yaml { }).generate "k0s.yaml" {
+    apiVersion = "k0s.k0sproject.io/v1beta1";
+    kind = "Cluster";
+    metadata = {
+      name = cfg.clusterName;
+    };
+    inherit (cfg) spec;
+  };
+
+  validatedConfig =
+    pkgs.runCommand "k0s.yaml-validated"
+      {
+        preferLocalBuild = true;
+      }
+      ''
+        ln -s ${cfg.configFile} $out
+        ${cfg.package}/bin/k0s config validate --config $out
+      '';
+
+  canValidate = pkgs.stdenv.buildPlatform.canExecute pkgs.stdenv.hostPlatform;
+
+  deployedConfig =
+    if cfg.validateConfig && canValidate then cfg.validatedConfigFile else cfg.configFile;
 in
 {
   imports = [
@@ -107,6 +134,50 @@ in
       default = "";
       type = str;
     };
+
+    configFile = mkOption {
+      description = ''
+        The generated k0s configuration, as it is placed in
+        `/etc/k0s/k0s.yaml`. Build this to read what the module makes
+        of the options set on it.
+      '';
+      type = package;
+      readOnly = true;
+      default = generatedConfig;
+      defaultText = literalMD "the configuration generated from {option}`services.k0s.spec`";
+    };
+
+    validatedConfigFile = mkOption {
+      description = ''
+        {option}`services.k0s.configFile` with `k0s config validate`
+        run over it while building. Build this attribute to get the
+        validation result on its own, without making the system build
+        depend on it.
+
+        It runs the packaged k0s binary, so it needs a builder that can
+        execute it.
+      '';
+      type = package;
+      readOnly = true;
+      default = validatedConfig;
+      defaultText = literalMD "{option}`services.k0s.configFile`, validated";
+    };
+
+    validateConfig = mkOption {
+      description = ''
+        Whether the system build depends on
+        {option}`services.k0s.validatedConfigFile`, so that an invalid
+        configuration fails the build instead of the node.
+
+        Off by default: it runs the packaged k0s binary on the builder,
+        and ties every build to the rules of one k0s version. It is
+        skipped where the builder cannot execute the binary, which is
+        why {option}`services.k0s.validatedConfigFile` stays the way to
+        ask for an answer rather than a default.
+      '';
+      type = bool;
+      default = false;
+    };
   };
 
   config =
@@ -117,14 +188,6 @@ in
       isLeader = (cfg.role == "single") || (cfg.controller.isLeader or false);
       requireJoinToken = isWorker || (!isLeader && !isExternalEtcd);
       unitName = "k0s";
-      configFile = (pkgs.formats.yaml { }).generate "k0s.yaml" {
-        apiVersion = "k0s.k0sproject.io/v1beta1";
-        kind = "Cluster";
-        metadata = {
-          name = cfg.clusterName;
-        };
-        inherit (cfg) spec;
-      };
       forbiddenArgs = [
         "--data-dir"
         "--config"
@@ -142,7 +205,7 @@ in
         }
       ];
 
-      environment.etc."k0s/k0s.yaml".source = configFile;
+      environment.etc."k0s/k0s.yaml".source = deployedConfig;
 
       systemd.services.${unitName} = {
         description = "k0s - Zero Friction Kubernetes";
@@ -168,7 +231,7 @@ in
           Restart = "always";
           ExecStart =
             "${cfg.package}/bin/k0s ${subcommand} --data-dir=${cfg.dataDir}"
-            + optionalString (cfg.role != "worker") " --config=${configFile}"
+            + optionalString (cfg.role != "worker") " --config=${deployedConfig}"
             + optionalString (cfg.role == "single") " --single"
             + optionalString (cfg.role == "controller+worker") " --enable-worker --no-taints"
             + optionalString requireJoinToken " --token-file=${cfg.tokenFile}"

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -172,9 +172,7 @@ in
 
         Off by default: it runs the packaged k0s binary on the builder,
         and ties every build to the rules of one k0s version. It is
-        skipped where the builder cannot execute the binary, which is
-        why {option}`services.k0s.validatedConfigFile` stays the way to
-        ask for an answer rather than a default.
+        skipped silently where the builder cannot execute that binary.
       '';
       type = bool;
       default = false;

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -47,7 +47,7 @@ let
   canValidate = pkgs.stdenv.buildPlatform.canExecute pkgs.stdenv.hostPlatform;
 
   deployedConfig =
-    if cfg.validateConfig && canValidate then cfg.validatedConfigFile else cfg.configFile;
+    if cfg.enableConfigCheck && canValidate then cfg.validatedConfigFile else cfg.configFile;
 in
 {
   imports = [
@@ -164,7 +164,7 @@ in
       defaultText = literalMD "{option}`services.k0s.configFile`, validated";
     };
 
-    validateConfig = mkOption {
+    enableConfigCheck = mkOption {
       description = ''
         Whether the system build depends on
         {option}`services.k0s.validatedConfigFile`, so that an invalid

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -169,9 +169,11 @@ in
         the system build instead of the node. What the node deploys is
         the same either way.
 
-        Off by default: it runs the packaged k0s binary on the builder,
-        and ties every build to the rules of one k0s version. It is
-        skipped silently where the builder cannot execute that binary.
+        Off by default: it runs {option}`services.k0s.package` on the
+        builder, so the rules applied are those of the k0s version this
+        host runs, and a version bump can fail a build that passed
+        before. It is skipped silently where the builder cannot execute
+        that binary.
       '';
       type = bool;
       default = false;

--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -76,24 +76,22 @@ in
       default = "single";
     };
 
-    controller = lib.optionalAttrs (cfg.role == "controller" || cfg.role == "controller+worker") (
-      lib.mkOption {
-        description = ''
-          Controller specific configuration
-        '';
-        type = submodule {
-          options = {
-            isLeader = lib.mkOption {
-              description = ''
-                The leader is used to generate the join tokens.
-              '';
-              default = false;
-            };
+    controller = mkOption {
+      description = ''
+        Controller specific configuration
+      '';
+      type = submodule {
+        options = {
+          isLeader = mkOption {
+            description = ''
+              The leader is used to generate the join tokens.
+            '';
+            default = false;
           };
         };
-        default = { };
-      }
-    );
+      };
+      default = { };
+    };
 
     dataDir = mkOption {
       description = ''
@@ -187,7 +185,7 @@ in
       subcommand = if (cfg.role == "worker") then "worker" else "controller";
       isExternalEtcd = cfg.spec.storage.type == "etcd" && cfg.spec.storage.etcd.externalCluster != null;
       isWorker = cfg.role == "worker";
-      isLeader = (cfg.role == "single") || (cfg.controller.isLeader or false);
+      isLeader = (cfg.role == "single") || cfg.controller.isLeader;
       requireJoinToken = isWorker || (!isLeader && !isExternalEtcd);
       unitName = "k0s";
       forbiddenArgs = [

--- a/nixos/kuberouter.nix
+++ b/nixos/kuberouter.nix
@@ -24,7 +24,7 @@ in
 
     mtu = mkOption {
       description = ''
-        Override MTU setting, if `autoMTU` must be set to `false`).
+        Override MTU setting. Requires `autoMTU` to be set to `false`.
       '';
       type = ints.unsigned;
       default = 0;

--- a/nixos/kuberouter.nix
+++ b/nixos/kuberouter.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   ...
 }@args:
 let
@@ -23,12 +22,13 @@ in
       default = true;
     };
 
-    mtu = util.mkOptionMandatoryIf (!config.autoMTU) {
+    mtu = mkOption {
       description = ''
         Override MTU setting, if `autoMTU` must be set to `false`).
       '';
       type = ints.unsigned;
-    } 0;
+      default = 0;
+    };
 
     metricsPort = mkOption {
       description = ''

--- a/nixos/network.nix
+++ b/nixos/network.nix
@@ -1,12 +1,10 @@
 {
   lib,
-  config,
   ...
 }@args:
 let
-  inherit (lib) mkEnableOption mkOption optionalAttrs;
-  inherit (lib.types) str enum submodule;
-  util = import ./util.nix args;
+  inherit (lib) mkEnableOption mkOption;
+  inherit (lib.types) enum submodule;
   customTypes = import ./types.nix args;
 in
 {
@@ -52,41 +50,40 @@ in
       default = "cluster.local";
     };
 
-    kuberouter = optionalAttrs (config.provider == "kuberouter") (mkOption {
+    kuberouter = mkOption {
       description = "Options for the `kuberouter` network provider.";
       type = submodule (import ./kuberouter.nix);
       default = { };
-    });
+    };
 
-    calico = optionalAttrs (config.provider == "calico") (mkOption {
+    calico = mkOption {
       description = "Options for the `calico` network provider.";
       type = submodule (import ./calico.nix);
       default = { };
-    });
+    };
 
-    dualStack =
-      optionalAttrs
-        (config.provider == "kuberouter" || (config.provider == "calico" && config.calico.mode == "bird"))
-        {
-          enabled = mkEnableOption ''
-            Defines whether or not IPv4/IPv6 dual-stack networking should be enabled.
-            With Calico, dual stack only works in bird mode.
-          '';
+    dualStack = {
+      enabled = mkEnableOption ''
+        Defines whether or not IPv4/IPv6 dual-stack networking should be enabled.
+        With Calico, dual stack only works in bird mode.
+      '';
 
-          IPv6podCIDR = util.mkOptionMandatoryIf config.dualStack.enabled {
-            description = ''
-              IPv6 Pod network CIDR to use in the cluster.
-            '';
-            type = if config.dualStack.enabled then customTypes.cidrV6 else str;
-          } "";
+      IPv6podCIDR = mkOption {
+        description = ''
+          IPv6 Pod network CIDR to use in the cluster.
+        '';
+        type = customTypes.emptyOrCidrV6;
+        default = "";
+      };
 
-          IPv6serviceCIDR = util.mkOptionMandatoryIf config.dualStack.enabled {
-            description = ''
-              IPv6 Network CIDR to use for cluster VIP services.
-            '';
-            type = if config.dualStack.enabled then customTypes.cidrV6 else str;
-          } "";
-        };
+      IPv6serviceCIDR = mkOption {
+        description = ''
+          IPv6 Network CIDR to use for cluster VIP services.
+        '';
+        type = customTypes.emptyOrCidrV6;
+        default = "";
+      };
+    };
 
     kubeProxy = mkOption {
       description = "Defines the configuration for kube-proxy.";

--- a/nixos/nllb.nix
+++ b/nixos/nllb.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  config,
   ...
 }@args:
 let
-  inherit (lib) mkEnableOption mkOption optionalAttrs;
+  inherit (lib) mkEnableOption mkOption;
   inherit (lib.types)
     enum
     port
@@ -26,7 +25,7 @@ in
       default = "EnvoyProxy";
     };
 
-    envoyProxy = optionalAttrs (config.enabled && config.type == "EnvoyProxy") (mkOption {
+    envoyProxy = mkOption {
       description = ''
         Configuration options related to the "EnvoyProxy" type of load balancing.
       '';
@@ -58,6 +57,6 @@ in
         };
       };
       default = { };
-    });
+    };
   };
 }

--- a/nixos/storage.nix
+++ b/nixos/storage.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  config,
   dataDir,
   ...
 }@args:
 let
-  inherit (lib) mkOption optionalAttrs;
+  inherit (lib) mkOption;
   inherit (lib.types)
     str
     enum
@@ -31,7 +30,7 @@ in
       default = "etcd";
     };
 
-    etcd = optionalAttrs (config.type == "etcd") {
+    etcd = {
       peerAddress = mkOption {
         description = ''
           Node address used for etcd cluster peering.
@@ -103,7 +102,7 @@ in
       };
     };
 
-    kine = optionalAttrs (config.type == "kine") {
+    kine = {
       dataSource = mkOption {
         description = ''
           [kine](https://github.com/k3s-io/kine) datasource URL.

--- a/nixos/types.nix
+++ b/nixos/types.nix
@@ -191,6 +191,7 @@ rec {
     description = "IPv6 CIDR";
   };
   cidr = either cidrV4 cidrV6;
+  emptyOrCidrV6 = either (enum [ "" ]) cidrV6;
   ipV4WithPort = addCheck str isValidIpV4WithPort // {
     description = "IPv4 address with port";
   };

--- a/nixos/util.nix
+++ b/nixos/util.nix
@@ -12,8 +12,4 @@ in
       example = literalExpression example;
       inherit description;
     });
-
-  mkOptionMandatoryIf =
-    condition: option: default:
-    mkOption (if condition then option else option // { inherit default; });
 }


### PR DESCRIPTION
When looking into the problem behind #27 I tried to use the validation of k0s. This PR contains the result I came up with.

The basic ideas:
- make it opt-in
- allow to run just validation locally by building a special attribute

There is a bigger controversial change in here though: The validation which was replicating what k0s itself checks is gone. This has a positive impact regarding the rendered module documentation, because it does now show it all. But it also means that errors are caught later.

On the positive side, error mesages should be now better, because they contain the knowledge from inside k0s.