### PR TITLE
test: the `cluster` test is a bit flaky

### DIFF
--- a/tests/cluster.nix
+++ b/tests/cluster.nix
@@ -43,16 +43,29 @@ in
       inherit (nodes.wrkr1.services.k0s) tokenFile;
     in
     ''
+      import time
+
       start_all()
       ctrl.wait_for_unit("k0s")
       ctrl.wait_for_file("/run/k0s/status.sock")
       ctrl.succeed("${k0s}/bin/k0s status")
 
-      def mkJoinToken():
+      def tryCreateJoinToken():
         (exit_code, stdout) = ctrl.execute("${k0s}/bin/k0s token create --role=worker 2>&1")
         if exit_code != 0:
           raise Exception(f"failed to create join token ({exit_code}): {stdout}")
         return stdout.strip()
+
+      def mkJoinToken(retries = 2):
+        try:
+          return tryCreateJoinToken()
+        except Exception as e:
+          print(e)
+          # this is known to be flaky, wait a bit and retry
+          if retries == 0:
+            raise e
+          time.sleep(0.1)
+          return mkJoinToken(retries - 1)
 
       for node in [wrkr1, wrkr2]:
         info=node.get_unit_info("k0s")


### PR DESCRIPTION
Creating a join token sometimes fails, probably because the api server isn't quite ready / stabilized. This adds a few retries to the function that generates the token so we reduce the likelihood of the test failing due to this transient state.

Example flake: https://github.com/nix-community/k0s-nix/actions/runs/33290482002/job/99270208454?pr=135